### PR TITLE
Non-block helpers, non-js-identifier helper names, Helper parsing changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ Hyperbars.registerHelper('hello', function(context, parameters, callback){
 });
 ```
 
-Would would, of course, render `{{hello name="World"}}` as `Hello, world!`.
+Would would, of course, render `{{hello name="World"}}` as `Hello, World!`.
 
 Note that you CAN mix positional and named parameters in the same helper call.
 
 So, `{{hello name="world" "foo" "bar"}}` would give `parameters` like `{name:"world", 0:"foo",1:"bar",length:2}`.
 
-Note that this means that the `parameters` parameter is both traditional object (keys = values) and an "Array-like" object, suitable for use with `Array.from(parameters)` to convert it to a proper Array that you can use with `.map()`, etc.
+Note that this means that the `parameters` parameter is both a traditional object (keys = values) and an "Array-like" object, suitable for use with `Array.from(parameters)` to convert it to a proper Array that you can use with `.map()`, etc.
 
 ## v0.1.2
 * Added helpers!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hyperbars
 Compile [Handlebars](http://handlebarsjs.com/) templates to javascript which can be used with [Virtual DOM](https://github.com/Matt-Esch/virtual-dom).
-This library offers a comprehensive coverage of the Handlebars API and more features will be added soon. Your [Handlebars](http://handlebarsjs.com/) templates 
-should work correctly without any modifications. 
+This library offers a comprehensive coverage of the Handlebars API and more features will be added soon. Your [Handlebars](http://handlebarsjs.com/) templates
+should work correctly without any modifications.
 
 Compiles something like this:
 ```html
@@ -103,28 +103,51 @@ Step 2: Use it in your Handlebars template
 To view more on partials please visit see [handlebars partials](http://handlebarsjs.com/partials.html).
 
 ## Helpers
-Hyperbars helpers are slightly different from the helpers found in Handlebars. 
+Hyperbars helpers are slightly different from the helpers found in Handlebars.
 
 Step 1: Register helper with Hyperbars. Always return and empty string if nothing should be displayed. The callback
 function has three arguments `callback(newContext, parentContext, options)`.
 ```js
-Hyperbars.registerHelper('equals', function(context, expression, callback){
-	if(expression.value.left === expression.value.right){
-		return callback(expression.value.left, context, {});
+Hyperbars.registerHelper('equals', function(context, parameters, callback){
+	if(parameters[0] === parameters[1]){
+		return callback(parameters[1], context, {});
 	}
 	return "";
 });
 ```
 
-Step 2: Use the helper in your template. In this example `value.left` is equal to `count` and `value.right` is equal
-to `"5"`. If your expression does not have a `=` sign then `value` is simply equal to the context property specified.
+Step 2: Use the helper in your template. In this example `parameters[0]` is equal to `count` and `parameters[1]` is equal
+to `5`.
 ```html
 <div>
-    {{#equals count="5"}}
+    {{#equals count 5}}
         <p>You won with a count of {{this}}!</p>
     {{/if}}
 </div>
 ```
+It is important to note that the `parameters` argument an "Array-like" object, suitable for use with `Array.from(parameters)` to convert it to a proper Array that you can use with `.map()`, etc. It is not an array by itself - it also has key/value pairs, as illustrated below.
+
+### Named Parameters
+
+Named parameters for helpers are supported naturally via the second `parameters` argument. For example:
+
+```html
+{{hello name="World"}}
+```
+Would correspond to:
+```js
+Hyperbars.registerHelper('hello', function(context, parameters, callback){
+	return callback("Hello, " + parameters.name + "!", context, {});
+});
+```
+
+Would would, of course, render `{{hello name="World"}}` as `Hello, world!`.
+
+Note that you CAN mix positional and named parameters in the same helper call.
+
+So, `{{hello name="world" "foo" "bar"}}` would give `parameters` like `{name:"world", 0:"foo",1:"bar",length:2}`.
+
+Note that this means that the `parameters` parameter is both traditional object (keys = values) and an "Array-like" object, suitable for use with `Array.from(parameters)` to convert it to a proper Array that you can use with `.map()`, etc.
 
 ## v0.1.2
 * Added helpers!

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   },
   "homepage": "https://github.com/vincentracine/hyperbars#readme",
   "dependencies": {
+    "htmlparser2": "^3.10.0",
     "virtual-dom": "git+https://github.com/vincentracine/virtual-dom.git"
+  },
+  "devDependencies": {
+    "colors": "^1.3.2"
   }
 }

--- a/src/hyperbars.js
+++ b/src/hyperbars.js
@@ -293,7 +293,7 @@ module.exports = Hyperbars = (function(Hyperbars){
 								if(string.indexOf("''+") == 0){
 									string = string.slice(3);
 								}
-								return string.trim() ? string : "null";
+								return string;
 							}
 						});
 

--- a/src/hyperbars.js
+++ b/src/hyperbars.js
@@ -252,6 +252,7 @@ module.exports = Hyperbars = (function(Hyperbars){
 			 * @param expression
 			 * @returns {*}
 			 */
+			var parsedExpressionCounter = 0; // for _identity
 			var expression2js = function(expression){
 				if(expression.indexOf('{{/') > -1){
 					return ']})';
@@ -315,7 +316,7 @@ module.exports = Hyperbars = (function(Hyperbars){
 				return [
 					"Runtime['",
 					fn.replace(/'/g, '\\\''),
-					"'](context, " + "{ " + parameters.join(', ') + " }" + ", function(context, parent, options){return ["
+					"'](context, " + "{ " + parameters.join(', ') + ", _identity: '_" + (parsedExpressionCounter ++) + '_' + Date.now () + "' }" + ", function(context, parent, options){return ["
 				].join('');
 			};
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
  * Hyperbars tests
  *
  * Copyright (c) 2016 Vincent Racine
+ * Added tests for new cases, 2018 Josiah Bryan
  * @license MIT
  */
 
@@ -232,6 +233,60 @@ test('Output HTML', function(){
 	var state = { html:"<h1>Hello World</h1>" };
 	var compiled = Hyperbars.compile(html);
 	return htmlOf(compiled, state) == expect;
+});
+test('Block helper {{#equals count="5"}}...{{/equals}}', function(){
+	Hyperbars.registerHelper('equals', function(context, expression, callback){
+		if(expression.value.left === expression.value.right){
+			return callback(expression.value.left, context, {});
+		}
+		return "";
+	});
+	var html   = "<div>{{#equals count=\"5\"}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
+	var expect = "<div><p>You won with a count of 5!</p></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled, { count: 5 }) == expect;
+	return match;
+});
+test('Non-block helper {{hello}}', function(){
+	Hyperbars.registerHelper('hello', function(context, expression, callback){
+		return callback("world", context, {});
+	});
+
+	var html   = "<div>Hello {{hello}}!</div>";
+	var expect = "<div>Hello world!</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
+test('Non-javascript helper names {{hello-world}}', function(){
+	Hyperbars.registerHelper('hello-world', function(context, expression, callback){
+		return callback("Hello, world", context, {});
+	});
+
+	var html   = "<div>{{hello-world}}!</div>";
+	var expect = "<div>Hello, world!</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
+test('Partial tree special-cased from helper callback', function(){
+	Hyperbars.registerHelper('hello-world', function(context, expression, callback){
+		return callback({ h: [ 'div', {'id': 'myid' }, [] ] }, context, {});
+	});
+
+	var html   = "<div>{{hello-world}}</div>";
+	var expect = "<div><div id=\"myid\"></div></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
+
+test('Raw html special-cased from helper callback', function(){
+	Hyperbars.registerHelper('hello-world', function(context, expression, callback){
+		return callback({ html: "<div id=\"myid\"></div>" }, context, {});
+	});
+
+	var html   = "<div>{{hello-world}}</div>";
+	var expect = "<div><div><div id=\"myid\"></div></div></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
 });
 
 console.log("Passed: " + ("" + passed).green, "| Failed: " + ("" + failed)[failed > 0 ? "red" : "green"]);

--- a/test.js
+++ b/test.js
@@ -305,6 +305,16 @@ test('Non-block helper - named params {{hello name="world"}}', function(){
 	var compiled = Hyperbars.compile(html);
 	return htmlOf(compiled) == expect;
 });
+test('Non-block helper - named params and string concat {{hello name="world"}}', function(){
+	Hyperbars.registerHelper('hello', function(context, expression, callback){
+		return callback("Hello, " + expression.name + "!", context, {});
+	});
+
+	var html   = "<div>{{hello name=\"world\"}}</div>";
+	var expect = "<div>Hello, world!</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
 test('Non-block helper - positional params {{hello "world"}}', function(){
 	Hyperbars.registerHelper('hello', function(context, expression, callback){
 		if(!expression.length)

--- a/test.js
+++ b/test.js
@@ -234,18 +234,56 @@ test('Output HTML', function(){
 	var compiled = Hyperbars.compile(html);
 	return htmlOf(compiled, state) == expect;
 });
-test('Block helper {{#equals count="5"}}...{{/equals}}', function(){
+test('Block helper - positional params {{#equals count 5}}...{{/equals}}', function(){
 	Hyperbars.registerHelper('equals', function(context, expression, callback){
-		if(expression.value.left === expression.value.right){
-			return callback(expression.value.left, context, {});
+		if(expression[0] == expression[1]){
+			return callback(expression[1], context, {});
 		}
 		return "";
 	});
-	var html   = "<div>{{#equals count=\"5\"}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
+	var html   = "<div>{{#equals count 5}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
 	var expect = "<div><p>You won with a count of 5!</p></div>";
 	var compiled = Hyperbars.compile(html);
 	return htmlOf(compiled, { count: 5 }) == expect;
-	return match;
+});
+test('Block helper - named params {{#equals left=count right=5}}...{{/equals}}', function(){
+	Hyperbars.registerHelper('equals', function(context, expression, callback){
+		// console.log('{{equals}}', { context, expression });
+		if(expression.left == expression.right){
+			return callback(expression.right, context, {});
+		}
+		return "";
+	});
+	var html   = "<div>{{#equals left=count right=5}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
+	var expect = "<div><p>You won with a count of 5!</p></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled, { count: 5 }) == expect;
+});
+test('Block helper - mixed named and positional params {{#equals count is=5}}...{{/equals}}', function(){
+	Hyperbars.registerHelper('equals', function(context, expression, callback){
+		// console.log('{{equals}}', { context, expression });
+		if(expression[0] == expression.is){
+			return callback(expression.is, context, {});
+		}
+		return "";
+	});
+	var html   = "<div>{{#equals count is=5}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
+	var expect = "<div><p>You won with a count of 5!</p></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled, { count: 5 }) == expect;
+});
+test('Block helper - quoted {{#equals count is="5"}}...{{/equals}}', function(){
+	Hyperbars.registerHelper('equals', function(context, expression, callback){
+		// console.log('{{equals}}', { context, expression });
+		if(expression[0] == expression.is){
+			return callback(expression.is, context, {});
+		}
+		return "";
+	});
+	var html   = "<div>{{#equals count is='5'}}<p>You won with a count of {{this}}!</p>{{/if}}</div>";
+	var expect = "<div><p>You won with a count of 5!</p></div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled, { count: 5 }) == expect;
 });
 test('Non-block helper {{hello}}', function(){
 	Hyperbars.registerHelper('hello', function(context, expression, callback){
@@ -256,6 +294,43 @@ test('Non-block helper {{hello}}', function(){
 	var expect = "<div>Hello world!</div>";
 	var compiled = Hyperbars.compile(html);
 	return htmlOf(compiled) == expect;
+});
+test('Non-block helper - named params {{hello name="world"}}', function(){
+	Hyperbars.registerHelper('hello', function(context, expression, callback){
+		return callback(expression.name, context, {});
+	});
+
+	var html   = "<div>Hello {{hello name=\"world\"}}!</div>";
+	var expect = "<div>Hello world!</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
+test('Non-block helper - positional params {{hello "world"}}', function(){
+	Hyperbars.registerHelper('hello', function(context, expression, callback){
+		if(!expression.length)
+			return "";
+		return callback(expression[0] || {}, context, {});
+	});
+
+	var html   = "<div>Hello {{hello 'world'}}!</div>";
+	var expect = "<div>Hello world!</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+});
+test('Non-block helper - true/false positional params {{does true false}}', function(){
+	Hyperbars.registerHelper('does', function(context, expression, callback){
+		return callback(Array.from(expression).join('!='), context, {});
+	});
+
+	var html   = "<div>Yes, {{does true false}}</div>";
+	var expect = "<div>Yes, true!=false</div>";
+	var compiled = Hyperbars.compile(html);
+	return htmlOf(compiled) == expect;
+
+	// console.log("Raw fn:", Hyperbars.compile(html, { raw: true }).toString(), "\n");
+	// const got = htmlOf(compiled, {});
+	// console.log({got, expect});
+	// return got == expect;
 });
 test('Non-javascript helper names {{hello-world}}', function(){
 	Hyperbars.registerHelper('hello-world', function(context, expression, callback){


### PR DESCRIPTION
Updated `hyperbars.js` to included:
  - Added support for non-block helpers - ex `{{current-time}}`
  - Added support for helper names that aren't valid JavaScript variable names (e.x. "`url-for`")
  - Added support for helpers without arguments
  - Added support for special-case context values from non-block helpers `{h: [...]}` and `{html:""}` - see test cases
  - [**Breaking Change**] Changed helper parsing to parse positional and named params like Handlebars
    - (e.x. `{{hello name="world" num=counter}}` would give a second arg to the helper like `{name:"world", num: context['counter'}`), and `{{hello "world" counter}}` would give `{0:"world",1:context['counter'],length:2}`.
    - Note that the second arg is an array-like object, suitable for use with `Array.from()`.
    - Note that all internal helpers (`{{#if}}`, `{{#each}}`, etc) have been updated for new API, and all tests pass
    - The largest API change is that helpers that do `expression.value.left` to get the first positional argument (like `{{#each person}}`) would just do `expression[0]` instead.
    - `README.md` has been updated with documentation on the usage of the new helper params object

Note: Test cases added for all changes in `test.js`